### PR TITLE
Feature/fixCategorySection/#21

### DIFF
--- a/src/components/Mypage/CategorySection.tsx
+++ b/src/components/Mypage/CategorySection.tsx
@@ -89,7 +89,7 @@ const CategorySectionWrapper = styled.section`
   flex-direction: column;
   align-items: center;
 
-  margin: 4.5rem 4.9rem;
+  margin: 4.5rem 5.6rem;
 `;
 
 const CreatedStoredWrapper = styled.div`
@@ -132,7 +132,7 @@ const FilterSection = styled.span`
 
   width:180.8rem;
 
-  margin: 0 11rem 2.4rem 11rem;
+  margin-bottom: 2.4rem;
 
   img {
     width: 2.4rem;
@@ -164,7 +164,7 @@ const CardContainer = styled.div`
   width: 21.2rem;
   height: 14rem;
 
-  margin-bottom: 4.5rem;
+ 
 
   h2 {
     position: absolute;

--- a/src/components/Mypage/CategorySection.tsx
+++ b/src/components/Mypage/CategorySection.tsx
@@ -87,6 +87,7 @@ export default CategorySection;
 const CategorySectionWrapper = styled.section`
   display: flex;
   flex-direction: column;
+  align-items: center;
 
   margin: 4.5rem 4.9rem;
 `;
@@ -129,6 +130,8 @@ const FilterSection = styled.span`
   flex-direction: row;
   justify-content: space-between;
 
+  width:180.8rem;
+
   margin: 0 11rem 2.4rem 11rem;
 
   img {
@@ -140,7 +143,10 @@ const FilterSection = styled.span`
 const CardSection = styled.section`
   display: flex;
   flex-direction: row;
+  
   justify-content: center;
+
+  width: 180.8rem;
 
   gap: 1.6rem;
 


### PR DESCRIPTION
## 🌈 구현 결과물 (이미지 첨부 필수)
![image](https://github.com/GOSOPT-CDS-TEAM7-DeskTop/Frontend/assets/91827379/a6f5217f-f136-498d-92ec-acf96565011e)


## ✨ 구현 기능 명세
- 아주 소소하긴 하지만, 기존 filterSection과 CategorySection의 좌우 마진이 따로 노는 바람에 화면비율이 줄어들 때 위치가 바뀌는 이슈가 발생했어서  CategorySection에서의 filtersection의 너비값을 CardSection과 맞춰 좌우 여백 5.6rem으로 통일시켜줬습니다.

## ❤️ 공유하고싶은 부분
-없음

## 🏠 추가 하고 싶은 말 (비고)
- 없음