### PR TITLE
Feature/styleReorganization/#54

### DIFF
--- a/src/components/Mypage/CardData.tsx
+++ b/src/components/Mypage/CardData.tsx
@@ -1,53 +1,61 @@
-const CardData = [
-    {
-      imgSrc: "../../src/assets/images/category_img/category_img_1.png",
-      alt: "card_image_1",
-      title: "모든 핀",
-      info: ["핀 124개", "13주"],
-    },
-    {
-      imgSrc: "../../src/assets/images/category_img/category_img_2.png",
-      alt: "card_image_2",
-      title: "해커톤",
-      info: ["핀 16개", "13주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_3.png",
-        alt: "card_image_3",
-        title: "랜딩페이지",
-        info: ["핀 17개", "21주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_4.png",
-        alt: "card_image_4",
-        title: "프레젠테이션",
-        info: ["핀 12개", "24주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_5.png",
-        alt: "card_image_5",
-        title: "팜플렛",
-        info: ["핀 3개", "25주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_6.png",
-        alt: "card_image_6",
-        title: "명함 디자인",
-        info: ["핀 17개", "21주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_7.png",
-        alt: "card_image_7",
-        title: "UI 디자인",
-        info: ["핀 17개", "35주"],
-    },
-    {
-        imgSrc: "../../src/assets/images/category_img/category_img_8.png",
-        alt: "card_image_8",
-        title: "대시보드 디자인",
-        info: ["핀 18개", "21주"],
+import category_img_1 from "../../assets/images/category_img/category_img_1.png";
+import category_img_2 from "../../assets/images/category_img/category_img_2.png";
+import category_img_3 from "../../assets/images/category_img/category_img_3.png";
+import category_img_4 from "../../assets/images/category_img/category_img_4.png";
+import category_img_5 from "../../assets/images/category_img/category_img_5.png";
+import category_img_6 from "../../assets/images/category_img/category_img_6.png";
+import category_img_7 from "../../assets/images/category_img/category_img_7.png";
+import category_img_8 from "../../assets/images/category_img/category_img_8.png";
 
-    }
-  ];
-  
-  export default CardData;
+const CardData = [
+  {
+    imgSrc: category_img_1,
+    alt: "card_image_1",
+    title: "모든 핀",
+    info: ["핀 124개", "13주"],
+  },
+  {
+    imgSrc: category_img_2,
+    alt: "card_image_2",
+    title: "해커톤",
+    info: ["핀 16개", "13주"],
+  },
+  {
+    imgSrc: category_img_3,
+    alt: "card_image_3",
+    title: "랜딩페이지",
+    info: ["핀 17개", "21주"],
+  },
+  {
+    imgSrc: category_img_4,
+    alt: "card_image_4",
+    title: "프레젠테이션",
+    info: ["핀 12개", "24주"],
+  },
+  {
+    imgSrc: category_img_5,
+    alt: "card_image_5",
+    title: "팜플렛",
+    info: ["핀 3개", "25주"],
+  },
+  {
+    imgSrc: category_img_6,
+    alt: "card_image_6",
+    title: "명함 디자인",
+    info: ["핀 17개", "21주"],
+  },
+  {
+    imgSrc: category_img_7,
+    alt: "card_image_7",
+    title: "UI 디자인",
+    info: ["핀 17개", "35주"],
+  },
+  {
+    imgSrc: category_img_8,
+    alt: "card_image_8",
+    title: "대시보드 디자인",
+    info: ["핀 18개", "21주"],
+  },
+];
+
+export default CardData;

--- a/src/components/Mypage/CardData.tsx
+++ b/src/components/Mypage/CardData.tsx
@@ -1,0 +1,53 @@
+const CardData = [
+    {
+      imgSrc: "../../src/assets/images/category_img/category_img_1.png",
+      alt: "card_image_1",
+      title: "모든 핀",
+      info: ["핀 124개", "13주"],
+    },
+    {
+      imgSrc: "../../src/assets/images/category_img/category_img_2.png",
+      alt: "card_image_2",
+      title: "해커톤",
+      info: ["핀 16개", "13주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_3.png",
+        alt: "card_image_3",
+        title: "랜딩페이지",
+        info: ["핀 17개", "21주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_4.png",
+        alt: "card_image_4",
+        title: "프레젠테이션",
+        info: ["핀 12개", "24주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_5.png",
+        alt: "card_image_5",
+        title: "팜플렛",
+        info: ["핀 3개", "25주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_6.png",
+        alt: "card_image_6",
+        title: "명함 디자인",
+        info: ["핀 17개", "21주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_7.png",
+        alt: "card_image_7",
+        title: "UI 디자인",
+        info: ["핀 17개", "35주"],
+    },
+    {
+        imgSrc: "../../src/assets/images/category_img/category_img_8.png",
+        alt: "card_image_8",
+        title: "대시보드 디자인",
+        info: ["핀 18개", "21주"],
+
+    }
+  ];
+  
+  export default CardData;

--- a/src/components/Mypage/CategorySection.tsx
+++ b/src/components/Mypage/CategorySection.tsx
@@ -1,5 +1,6 @@
 import { styled } from "styled-components";
 import CardContainer from "./CardContainer";
+import CardData from "./CardData";
 
 const CategorySection = () => {
   return (
@@ -13,54 +14,9 @@ const CategorySection = () => {
         <img src="../../src/assets/icon/plus_icon.svg" alt="plus_icon" />
       </FilterSection>
       <CardSection>
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_1.png"
-          alt="card_image_1"
-          title="모든 핀"
-          info={["핀 124개", "13주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_2.png"
-          alt="card_image_2"
-          title="해커톤"
-          info={["핀 16개", "13주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_3.png"
-          alt="card_image_3"
-          title="랜딩페이지"
-          info={["핀 17개", "21주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_4.png"
-          alt="card_image_4"
-          title="프레젠테이션"
-          info={["핀 12개", "24주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_5.png"
-          alt="card_image_5"
-          title="팜플렛"
-          info={["핀 3개", "25주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_6.png"
-          alt="card_image_6"
-          title="명함 디자인"
-          info={["핀 17개", "21주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_7.png"
-          alt="card_image_7"
-          title="UI 디자인"
-          info={["핀 17개", "35주"]}
-        />
-        <CardContainer
-          imgSrc="../../src/assets/images/category_img/category_img_8.png"
-          alt="card_image_8"
-          title="대시보드 디자인"
-          info={["핀 18개", "21주"]}
-        />
+        {CardData.map((data, index) => {
+          return <CardContainer key={index} imgSrc={data.imgSrc} alt={data.alt} title={data.title} info={data.info} />;
+        })}
       </CardSection>
       <Line />
     </CategorySectionWrapper>
@@ -134,10 +90,7 @@ const CardSection = styled.section`
   width: 180.8rem;
 
   gap: 1.6rem;
-
 `;
-
-
 
 const Line = styled.div`
   width: 100%;

--- a/src/components/Mypage/CategorySection.tsx
+++ b/src/components/Mypage/CategorySection.tsx
@@ -1,6 +1,8 @@
 import { styled } from "styled-components";
 import CardContainer from "./CardContainer";
 import CardData from "./CardData";
+import filter_icon from "../../assets/icon/filter_icon.svg";
+import plus_icon from "../../assets/icon/plus_icon.svg";
 
 const CategorySection = () => {
   return (
@@ -10,8 +12,8 @@ const CategorySection = () => {
         <Stored>저장됨</Stored>
       </CreatedStoredWrapper>
       <FilterSection>
-        <img src="../../src/assets/icon/filter_icon.svg" alt="filter_icon" />
-        <img src="../../src/assets/icon/plus_icon.svg" alt="plus_icon" />
+        <img src={filter_icon} alt="filter_icon" />
+        <img src={plus_icon} alt="plus_icon" />
       </FilterSection>
       <CardSection>
         {CardData.map((data, index) => {

--- a/src/components/Mypage/SaveArticleSection.tsx
+++ b/src/components/Mypage/SaveArticleSection.tsx
@@ -38,13 +38,20 @@ const SaveArticleSection = () => {
 export default SaveArticleSection;
 
 const SaveArticleSectionWrapper = styled.section`
-  margin: 0 6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 180rem;
+  width: 100%;
 
   span {
     display: flex;
     justify-content: space-between;
     align-items: center;
 
+    width: 180rem;
     height: 3.6rem;
 
     margin-bottom: 2.6rem;
@@ -69,6 +76,6 @@ const SaveArticleSectionWrapper = styled.section`
 `;
 
 const MasonryWrapper = styled.section`
-  width: 100%;
+  width: 180rem;
   padding: 0;
 `;

--- a/src/components/Mypage/UserProfile.tsx
+++ b/src/components/Mypage/UserProfile.tsx
@@ -76,6 +76,8 @@ const FollowNum = styled.h3`
 const ButtonSection = styled.div`
   display: flex;
   gap: 0.7rem;
+
+  margin-bottom: 0.5rem;
 `;
 
 const ShareButton = styled.button`

--- a/src/components/Mypage/UserProfile.tsx
+++ b/src/components/Mypage/UserProfile.tsx
@@ -1,9 +1,7 @@
 import { styled } from "styled-components";
-import axios from "axios";
-import { useState, useEffect } from "react";
 import { useRecoilValue } from "recoil";
 import { userDataAtom } from "../../atoms/atom";
-import userDataHooks from "../../hooks/userDataHooks";
+
 
 function UserProfile() {
   const userData = useRecoilValue(userDataAtom);

--- a/src/components/common/QuestionMark.tsx
+++ b/src/components/common/QuestionMark.tsx
@@ -1,10 +1,11 @@
 import styled from "styled-components";
+import questionMark from "../../assets/icon/questionmark.svg";
 
 const QuestionMark = () => {
   return (
     <QuestionMarkWrapper>
       <button type="button">
-        <img src="../../src/assets/icon/questionmark.svg" alt="questionmark_icon" />
+        <img src={questionMark} alt="questionmark_icon" />
       </button>
     </QuestionMarkWrapper>
   );
@@ -27,5 +28,4 @@ const QuestionMarkWrapper = styled.div`
     background-color: ${({ theme }) => theme.colors.pinterest_white};
     box-shadow: 0 0 1.1rem rgba(0, 0, 0, 0.15);
   }
-
 `;


### PR DESCRIPTION
## 🌈 구현 결과물 (이미지 첨부 필수)
![image](https://github.com/GOSOPT-CDS-TEAM7-DeskTop/Frontend/assets/91827379/eae7c099-13af-4d2d-8c4c-3d22233f0492)
=> 달라진 이미지는 아주 세세한 마진 차이밖에 없습니다!
## ✨ 구현 기능 명세
- 중복되는 cardContainer 코드를 깔끔하게 다듬고자 cardData 컴포넌트로 따로 분리하여 map하는 방식으로 수정하였습니다.
- 배포 과정에서 렌더링이 안됐던 카테고리 이미지와 퀘스천마크 이미지, filtersection 이미지들을 import 방식으로 불러오도록 수정하였습니다.
- 유저프로필섹션 내 자잘한 margin 차이를 피그마와 동일하게 맞춰주었습니다.
- 유저프로필 컴포넌트 내 필요없는 import 구문을 삭제했습니다.
- 기존 화면 너비에 따라 고정되어 있는 다른 섹션과 달리 고정되지 않았던 saveArticleSection의 width를 동일하게 맞춰주었습니다.

## ❤️ 공유하고싶은 부분


## 🏠 추가 하고 싶은 말 (비고)
